### PR TITLE
fix build script commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .nyc_output
+*.log
 coverage
 node_modules

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   },
   "scripts": {
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "pretest": "standard",
+    "pretest": "npm run unbuild && standard",
     "test": "npm run build && ava && npm run unbuild",
-    "build": "mv lib src && babel src -d lib",
-    "unbuild": "rm -rf lib && mv src lib"
+    "build": "mkdir -p src && babel lib -d src",
+    "unbuild": "rm -f src/index.js"
   }
 }


### PR DESCRIPTION
This makes your build steps a bit more resilient to failure. For instance, if your tests fail the `unbuild` script will never get ran, and the next `test` will fail on `standard` linting.